### PR TITLE
Remove bower-asset vendor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,8 +67,7 @@
             "docroot/core": ["type:drupal-core"],
             "docroot/libraries/{$name}": [
                 "type:drupal-library",
-                "type:bower-asset",
-                "vendor:bower-asset"
+                "type:bower-asset"
             ],
             "docroot/modules/contrib/{$name}": ["type:drupal-module"],
             "docroot/profiles/contrib/{$name}": ["type:drupal-profile"],


### PR DESCRIPTION
After I have cleared composer cache, it fetched libraries correct and copied them to correct place. So only "type" is sufficient.