### PR TITLE
Fixed composer fails to load/call scripts when thunder-project is used as dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,9 +52,9 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {
-        "classmap": [
-            "scripts/composer/ScriptHandler.php"
-        ]
+        "psr-4": {
+            "DrupalProject\\composer\\": "scripts/composer/"
+        }
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",


### PR DESCRIPTION
Problem
* When using burdamagazinorg/thunder-project as dependency as shown below, `composer install` fails to invoke the scripts, because composer does not generate a new classmap for every dependency it installs.

```json
{
    "require-dev": {
        "burdamagazinorg/thunder-project": "^8.2.1"
    },
    "scripts": {
        "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
        "pre-install-cmd": [
            "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
        ],
        "pre-update-cmd": [
            "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
        ],
        "post-install-cmd": [
            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
        ],
        "post-update-cmd": [
            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
        ]
    },
}
```

Temporary Workaround
* Invoke `composer install` twice.  It properly loads and invokes the scripts in the second invocation, as all dependencies have been downloaded / installed already.

Proposed solution
1. Using PSR-4 instead of a classmap for autoloading resolves https://github.com/composer/composer/issues/1430 / https://github.com/composer/composer/issues/3739, which are claimed to be resolved, but only seem to work upon a second invocation of `composer install`.

API changes
* None; the script is loaded as before.
